### PR TITLE
refactor(ui): use an object to map journal instance type

### DIFF
--- a/packages/client/app/pages/Menu.page.tsx
+++ b/packages/client/app/pages/Menu.page.tsx
@@ -25,13 +25,20 @@ const MenuPage = (): ReactNode => {
   // @ts-ignore
   const { instanceName, groupIdentity, report, controlPanel } = config
 
+  const instances = {
+    journal: 'Journal',
+    prc: 'PRC',
+    preprint1: 'Preprint 1',
+    preprint2: 'Preprint 2',
+  }
+
   const showDashboard = ['journal', 'prc', 'preprint2'].includes(instanceName)
   const showCoar = controlPanel?.showTabs.includes('COAR Notify Metadata')
 
   return (
     <Menu
       groupDisplayName={groupIdentity.brandName}
-      groupType={instanceName}
+      groupType={instances[instanceName] ?? instanceName}
       initialMenuCollapsed={menuCollapsed}
       isUserAdmin={isUserAdmin}
       isUserGroupAdmin={isUserGroupAdmin}

--- a/packages/client/app/ui/base/Menu.tsx
+++ b/packages/client/app/ui/base/Menu.tsx
@@ -102,7 +102,7 @@ const GroupName = styled.div<{ $labelsWrap: boolean }>`
 
 const GroupType = styled.div`
   font-size: ${th('fontSizeBaseSmall')};
-  text-transform: capitalize;
+  /* text-transform: capitalize; */
 `
 
 const Separator = styled.div`
@@ -346,6 +346,7 @@ const Menu = (props: MenuProps): ReactNode => {
     showDashboard,
     showReports,
   } = props
+
   const { t } = useTranslation()
   const { pathname } = useLocation()
   const { groupName } = useParams()

--- a/packages/client/app/ui/base/Menu.tsx
+++ b/packages/client/app/ui/base/Menu.tsx
@@ -102,7 +102,6 @@ const GroupName = styled.div<{ $labelsWrap: boolean }>`
 
 const GroupType = styled.div`
   font-size: ${th('fontSizeBaseSmall')};
-  /* text-transform: capitalize; */
 `
 
 const Separator = styled.div`


### PR DESCRIPTION
Related to #411 

This PR changes how the group type is displayed in the Menu, using an object to map the instance name, rather than only capitalising it.